### PR TITLE
Fix for ZendGuard 5.3 problem

### DIFF
--- a/code/fields/UploadAnythingField.php
+++ b/code/fields/UploadAnythingField.php
@@ -606,7 +606,7 @@ class UploadAnythingField extends ComplexTableField {
 	 */
 	private function GetFileList() {
 		$html = "";
-		if(method_exists('DisplayAnythingFileList', $this->controller)) {
+		if(method_exists($this->controller,'DisplayAnythingFileList')) {
 			return $this->{$this->controller}->DisplayAnythingFileList();
 		} else {
 			$relation = $this->DataTypeRelation();


### PR DESCRIPTION
Not shure what the code is meant to do, but the syntax of method_exists
is
method_exists ( mixed $object , string $method_name ).

Anyhow there is not methode "DisplayAnythingFileList" but it fixes an
Issue with ZendGuard 5.3 enable on a Shared Host.
